### PR TITLE
Fixed replace method name

### DIFF
--- a/react-router.d.ts
+++ b/react-router.d.ts
@@ -235,7 +235,7 @@ declare module ReactRouter {
 		 *
 		 * @param {LocationDescriptor} pathOrLoc
 		 */
-		push(pathOrLoc: LocationDescriptor);
+		replace(pathOrLoc: LocationDescriptor);
 
 		/**
 		 * Go forward or backward in the history by n or -n.


### PR DESCRIPTION
`push` is defined twice in the `IRouter` interface. The second method should be `replace`.
