### PR TITLE
Allow static methods on components

### DIFF
--- a/react-router.d.ts
+++ b/react-router.d.ts
@@ -748,7 +748,7 @@ declare module ReactRouter {
 	 * @param {routes: RouteConfig}
 	 * @param {(error:Error, redirectLocation:Location, renderProps : Object) => void} callback
 	 */
-	export function match({routes: RouteConfig}, callback: (error: Error, redirectLocation: Location, renderProps: Object) => void): void;
+	export function match(args: IMatchArgs, callback: (error: Error, redirectLocation: Location, renderProps: any) => void): void;
 
 	/**
 	 * Creates and returns an array of routes from the given object which may be a JSX route, a plain object route, or an array of either.


### PR DESCRIPTION
Having a static method (e.g. `fetchData`) to fetch just the data required to render a component on the server is a standard practice for universal apps.

`renderProps: Object` as currently declared doesn't allow the static method, because `Object` doesn't have it on its own prototype. Declaring it as `any` will fix this problem.
