### PR TITLE
Fix location for match arguments

### DIFF
--- a/react-router.d.ts
+++ b/react-router.d.ts
@@ -722,7 +722,7 @@ declare module ReactRouter {
 	export interface IMatchArgs extends BasenameOptions, QueryOptions {
 		routes: RouteConfig;
 
-		location: Location;
+		location: LocationDescriptor;
 
 		history?: History;
 	}

--- a/react-router.d.ts
+++ b/react-router.d.ts
@@ -722,7 +722,7 @@ declare module ReactRouter {
 	export interface IMatchArgs extends BasenameOptions, QueryOptions {
 		routes: RouteConfig;
 
-		location: LocationDescriptor;
+		location?: LocationDescriptor;
 
 		history?: History;
 	}


### PR DESCRIPTION
`location` property for `IMatchArgs` should be `LocationDescriptor` because we can pass string as its value. It should be optional as well. Source: https://github.com/reactjs/react-router/blob/master/modules/match.js#L20
